### PR TITLE
Add Christ's Object Lessons Vietnamese translation pipeline

### DIFF
--- a/col-translator/.gitignore
+++ b/col-translator/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+chapters/*.txt
+chapters/manifest.json
+glossary/glossary.json
+translated/
+hugo-site/

--- a/col-translator/build_glossary.py
+++ b/col-translator/build_glossary.py
@@ -1,0 +1,217 @@
+"""Phase 2: Build a shared glossary via Claude API."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from anthropic import Anthropic
+
+BASE_DIR = Path(__file__).parent
+CHAPTERS_DIR = BASE_DIR / "chapters"
+GLOSSARY_DIR = BASE_DIR / "glossary"
+MANIFEST_PATH = CHAPTERS_DIR / "manifest.json"
+GLOSSARY_PATH = GLOSSARY_DIR / "glossary.json"
+
+MODEL = "claude-opus-4-5"
+BATCH_SIZE = 3
+MAX_TOKENS = 4096
+
+SEED_TERMS: list[dict] = [
+    {"en": "grace", "vi": "ân điển", "category": "theology", "note": "Ân điển cứu rỗi"},
+    {"en": "salvation", "vi": "sự cứu rỗi", "category": "theology", "note": ""},
+    {"en": "atonement", "vi": "sự chuộc tội", "category": "theology", "note": ""},
+    {"en": "righteousness", "vi": "sự công bình", "category": "theology", "note": ""},
+    {"en": "sanctification", "vi": "sự thánh hóa", "category": "theology", "note": ""},
+    {"en": "justification", "vi": "sự xưng công bình", "category": "theology", "note": ""},
+    {"en": "repentance", "vi": "sự ăn năn", "category": "theology", "note": ""},
+    {"en": "Holy Spirit", "vi": "Đức Thánh Linh", "category": "proper_noun", "note": "Always capitalize"},
+    {"en": "Sabbath", "vi": "Ngày Sa-bát", "category": "proper_noun", "note": ""},
+    {"en": "Scripture", "vi": "Kinh Thánh", "category": "proper_noun", "note": ""},
+    {"en": "parable", "vi": "ngụ ngôn", "category": "theology", "note": ""},
+    {"en": "kingdom of heaven", "vi": "nước thiên đàng", "category": "theology", "note": ""},
+    {"en": "kingdom of God", "vi": "nước Đức Chúa Trời", "category": "theology", "note": ""},
+    {"en": "Christ", "vi": "Đấng Christ", "category": "proper_noun", "note": ""},
+    {"en": "Father", "vi": "Đức Chúa Cha", "category": "proper_noun", "note": "When referring to God"},
+    {"en": "Son of God", "vi": "Con Đức Chúa Trời", "category": "proper_noun", "note": ""},
+    {"en": "gospel", "vi": "tin lành", "category": "theology", "note": ""},
+    {"en": "covenant", "vi": "giao ước", "category": "theology", "note": ""},
+    {"en": "faith", "vi": "đức tin", "category": "theology", "note": ""},
+    {"en": "sin", "vi": "tội lỗi", "category": "theology", "note": ""},
+]
+
+SYSTEM_PROMPT = """You are a senior Seventh-day Adventist theological translator (English -> Vietnamese).
+You are helping build a shared glossary for translating Ellen G. White's "Christ's Object Lessons" to Vietnamese.
+Your translations must match the Vietnamese Bible (1934 / truyền thống) register and SDA devotional usage.
+
+Content rules (MUST FOLLOW):
+- Always use "Đức Chúa Giê-su" (never "Chúa Giê-su", "Jesus", or "Giê-xu").
+- "Sa-bát" (not "Sabát").
+- "Do Thái Giáo" (not "Giu-đa-izt").
+- "Cơ-đốc" (not "Cơ Đốc").
+- Divine names capitalized: "Đức Chúa Trời", "Đức Thánh Linh", "Kinh Thánh", "Đức Chúa Giê-su".
+- When God/Chúa is the subject, use "ban phước" (never "chúc phước").
+"""
+
+USER_TEMPLATE = """Extract theological / thematic terms from the following English chapter(s) that will need
+**consistent** Vietnamese translation across the whole book.
+
+Categories (use these exact strings):
+- "theology"       : doctrinal words (grace, atonement, sanctification, righteousness, repentance, faith, salvation, covenant, kingdom of heaven, etc.)
+- "parable_title"  : named parables (The Sower, Prodigal Son, Talents, Ten Virgins, etc.)
+- "proper_noun"    : names / titles (Christ, Father, Holy Ghost, Sabbath, Scripture, Pharisee, etc.)
+- "ellen_white_idiom": distinctive phrases Ellen White reuses across the book
+
+Already in our seed glossary (do NOT repeat, but you may refine "note" if helpful):
+{seed_list}
+
+Output rules:
+- Output **only** a strict JSON array. No prose, no markdown fences.
+- Each element: {{"en": "...", "vi": "...", "category": "...", "note": "..."}}
+- "note" is optional context (<= 120 chars). Use "" if none.
+- Do not invent terms that don't appear in the text.
+
+CHAPTERS:
+{chapters_block}
+"""
+
+
+def load_manifest() -> list[dict]:
+    if not MANIFEST_PATH.exists():
+        raise SystemExit(f"Manifest not found: {MANIFEST_PATH}. Run phase 1 first.")
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def read_chapter(entry: dict) -> str:
+    return (CHAPTERS_DIR / entry["filename"]).read_text(encoding="utf-8")
+
+
+def chunk(seq: list, size: int):
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
+def _extract_json_array(text: str) -> list:
+    """Best-effort: locate the first JSON array in text and parse it."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:]
+        text = text.strip()
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("No JSON array found in response")
+    return json.loads(text[start : end + 1])
+
+
+def merge(glossary: dict[str, dict], incoming: list[dict]) -> None:
+    for item in incoming:
+        en = (item.get("en") or "").strip()
+        vi = (item.get("vi") or "").strip()
+        if not en or not vi:
+            continue
+        key = en.lower()
+        category = (item.get("category") or "theology").strip()
+        note = (item.get("note") or "").strip()
+        if key in glossary:
+            # Prefer longer / more specific note; never overwrite seed vi.
+            existing = glossary[key]
+            if len(note) > len(existing.get("note", "")):
+                existing["note"] = note
+        else:
+            glossary[key] = {"en": en, "vi": vi, "category": category, "note": note}
+
+
+def format_seed_list(seed: list[dict]) -> str:
+    lines = [f'- {s["en"]} -> {s["vi"]}' for s in seed]
+    return "\n".join(lines)
+
+
+def build() -> list[dict]:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise SystemExit("ANTHROPIC_API_KEY is not set")
+
+    GLOSSARY_DIR.mkdir(parents=True, exist_ok=True)
+    client = Anthropic(api_key=api_key)
+    manifest = load_manifest()
+    if not manifest:
+        raise SystemExit("Manifest is empty")
+
+    glossary: dict[str, dict] = {}
+    merge(glossary, SEED_TERMS)
+    seed_block = format_seed_list(SEED_TERMS)
+
+    total_batches = (len(manifest) + BATCH_SIZE - 1) // BATCH_SIZE
+
+    for bidx, batch in enumerate(chunk(manifest, BATCH_SIZE), start=1):
+        chapters_block_parts = []
+        for entry in batch:
+            body = read_chapter(entry)
+            chapters_block_parts.append(
+                f"=== {entry['id']} — {entry['title']} ===\n{body}"
+            )
+        chapters_block = "\n\n".join(chapters_block_parts)
+
+        user_prompt = USER_TEMPLATE.format(
+            seed_list=seed_block, chapters_block=chapters_block
+        )
+
+        print(f"[glossary batch {bidx}/{total_batches}] {[e['id'] for e in batch]}")
+        try:
+            resp = client.messages.create(
+                model=MODEL,
+                max_tokens=MAX_TOKENS,
+                system=SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+        except Exception as e:
+            print(f"  ! API error: {e}")
+            continue
+
+        text = "".join(
+            block.text for block in resp.content if getattr(block, "type", "") == "text"
+        )
+        try:
+            items = _extract_json_array(text)
+        except Exception as e:
+            print(f"  ! could not parse JSON: {e}")
+            print(f"  --- raw response (first 400 chars) ---\n{text[:400]}")
+            continue
+        merge(glossary, items)
+        print(f"  added {len(items)} candidate terms; total now {len(glossary)}")
+
+    final_list = sorted(glossary.values(), key=lambda x: (x["category"], x["en"].lower()))
+    GLOSSARY_PATH.write_text(
+        json.dumps(final_list, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(f"\nGlossary built: {len(final_list)} terms total -> {GLOSSARY_PATH}")
+    print_summary(final_list)
+    return final_list
+
+
+def print_summary(terms: list[dict]) -> None:
+    by_cat: dict[str, list[dict]] = {}
+    for t in terms:
+        by_cat.setdefault(t["category"], []).append(t)
+    print("\n=== Glossary Summary ===")
+    for cat in sorted(by_cat):
+        print(f"\n## {cat} ({len(by_cat[cat])})")
+        for t in sorted(by_cat[cat], key=lambda x: x["en"].lower())[:20]:
+            note = f"  — {t['note']}" if t.get("note") else ""
+            print(f"  {t['en']:<32} -> {t['vi']}{note}")
+
+
+def main() -> int:
+    if GLOSSARY_PATH.exists() and "--rebuild-glossary" not in sys.argv:
+        print(f"Phase 2 skip: glossary already exists at {GLOSSARY_PATH}.")
+        return 0
+    build()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/col-translator/crawler.py
+++ b/col-translator/crawler.py
@@ -1,0 +1,310 @@
+"""Phase 1: Crawl Christ's Object Lessons chapters from egwwritings.org.
+
+egwwritings.org's mobile site paginates chapter content: each URL
+`/en/book/15.<para_id>` returns a window of paragraphs centered on that para_id
+(typically 20-50 paragraphs). To get a full chapter we derive each chapter's
+start paragraph id from the TOC, then iterate requests stepping forward until
+we reach the next chapter's start id. Paragraphs are deduped by their
+`data-para-id` attribute.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+
+import httpx
+from bs4 import BeautifulSoup
+
+BASE_DIR = Path(__file__).parent
+CHAPTERS_DIR = BASE_DIR / "chapters"
+MANIFEST_PATH = CHAPTERS_DIR / "manifest.json"
+
+# Christ's Object Lessons is book id 15 on egwwritings.org.
+BOOK_ID = 15
+TOC_URLS = [
+    f"https://m.egwwritings.org/en/book/{BOOK_ID}/toc",
+    f"https://egwwritings.org/book/b{BOOK_ID}",
+]
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+RATE_LIMIT_SECONDS = 1.0
+MAX_RETRIES = 3
+PARA_STEP = 20  # how far to advance para-id between page fetches
+
+
+async def fetch(client: httpx.AsyncClient, url: str) -> str:
+    last_err: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = await client.get(url, headers=HEADERS, follow_redirects=True, timeout=30.0)
+            if resp.status_code >= 400:
+                raise httpx.HTTPStatusError(
+                    f"HTTP {resp.status_code}", request=resp.request, response=resp
+                )
+            return resp.text
+        except (httpx.HTTPError, httpx.RequestError) as e:
+            last_err = e
+            wait = 2 ** attempt
+            print(f"  ! fetch attempt {attempt+1} failed ({e}); retrying in {wait}s")
+            await asyncio.sleep(wait)
+    raise RuntimeError(f"Failed to fetch {url}: {last_err}")
+
+
+def _abs_url(href: str, base: str) -> str:
+    if href.startswith("http"):
+        return href
+    if href.startswith("//"):
+        return "https:" + href
+    if href.startswith("/"):
+        m = re.match(r"^(https?://[^/]+)", base)
+        if m:
+            return m.group(1) + href
+    return base.rstrip("/") + "/" + href.lstrip("/")
+
+
+CHAPTER_HREF_RE = re.compile(rf"/book/{BOOK_ID}\.(\d+)(?:/|$|\?|#)")
+
+
+def parse_toc(html: str, source_url: str) -> list[dict]:
+    """Extract chapter list. Each entry has {title, url, start_para}."""
+    soup = BeautifulSoup(html, "lxml")
+    items: list[dict] = []
+    seen_paras: set[int] = set()
+
+    for a in soup.select("a"):
+        href = a.get("href", "").strip()
+        title = " ".join(a.get_text(" ", strip=True).split())
+        if not href or not title:
+            continue
+        if href.rstrip("/").endswith("/toc") or href.rstrip("/").endswith("/info"):
+            continue
+        m = CHAPTER_HREF_RE.search(href)
+        if not m:
+            continue
+        low = title.lower()
+        if low in {"toc", "table of contents", "back", "home", "next", "previous", "read", "details"}:
+            continue
+        para = int(m.group(1))
+        if para in seen_paras:
+            continue
+        seen_paras.add(para)
+        items.append(
+            {
+                "title": title,
+                "url": _abs_url(href, source_url),
+                "start_para": para,
+            }
+        )
+    items.sort(key=lambda x: x["start_para"])
+    return items
+
+
+def extract_title(html: str, fallback: str) -> str:
+    soup = BeautifulSoup(html, "lxml")
+    for sel in ["h3.egw_content_wrapper", "h2.egw_content_wrapper", "h1.egw_content_wrapper", "h1", "h2", "h3"]:
+        el = soup.select_one(sel)
+        if el:
+            t = " ".join(el.get_text(" ", strip=True).split())
+            if t and len(t) < 200:
+                return t
+    return fallback
+
+
+def extract_paragraphs_in_range(
+    html: str, start: int, end_exclusive: int
+) -> list[tuple[int, str]]:
+    """Return list of (para_id_tail, text) for paragraphs within [start, end)."""
+    soup = BeautifulSoup(html, "lxml")
+    out: list[tuple[int, str]] = []
+    seen_ids: set[int] = set()
+
+    # Primary: look for any element with data-para-id="<BOOK_ID>.<N>"
+    for el in soup.select("[data-para-id]"):
+        pid = el.get("data-para-id", "")
+        m = re.match(rf"{BOOK_ID}\.(\d+)$", pid)
+        if not m:
+            continue
+        pnum = int(m.group(1))
+        if pnum in seen_ids or pnum < start or pnum >= end_exclusive:
+            continue
+        # Find the nearest content span (skip heading containers).
+        tag_name = getattr(el, "name", "")
+        if tag_name and tag_name.startswith("h"):
+            # chapter heading — skip for body extraction
+            continue
+        text_el = el.select_one("span.egw_content") or el
+        text = " ".join(text_el.get_text(" ", strip=True).split())
+        if text and len(text) > 10:
+            seen_ids.add(pnum)
+            out.append((pnum, text))
+    return out
+
+
+async def fetch_chapter_body(
+    client: httpx.AsyncClient, start_para: int, end_para_exclusive: int, title_hint: str
+) -> tuple[str, list[str]]:
+    """Fetch all pages needed to cover [start_para, end_para_exclusive) paragraphs."""
+    collected: dict[int, str] = {}
+    title = title_hint
+    cursor = start_para
+    pages_fetched = 0
+    max_pages = max(8, (end_para_exclusive - start_para) // PARA_STEP + 4)
+
+    while cursor < end_para_exclusive and pages_fetched < max_pages:
+        url = f"https://m.egwwritings.org/en/book/{BOOK_ID}.{cursor}"
+        try:
+            html = await fetch(client, url)
+        except Exception as e:
+            print(f"    ! page fetch failed at {cursor}: {e}")
+            break
+        pages_fetched += 1
+
+        if pages_fetched == 1:
+            title = extract_title(html, title_hint)
+
+        found = extract_paragraphs_in_range(html, start_para, end_para_exclusive)
+        if not found:
+            cursor += PARA_STEP
+            await asyncio.sleep(RATE_LIMIT_SECONDS)
+            continue
+        new_added = 0
+        max_pnum_in_page = cursor
+        for pnum, text in found:
+            max_pnum_in_page = max(max_pnum_in_page, pnum)
+            if pnum not in collected:
+                collected[pnum] = text
+                new_added += 1
+
+        # Advance cursor past what we got, with a little step to find the next window
+        if new_added == 0:
+            # nothing new — break to avoid infinite loop
+            break
+        cursor = max_pnum_in_page + 1
+
+        await asyncio.sleep(RATE_LIMIT_SECONDS)
+
+    paragraphs = [collected[k] for k in sorted(collected)]
+    return title, paragraphs
+
+
+async def crawl() -> list[dict]:
+    CHAPTERS_DIR.mkdir(parents=True, exist_ok=True)
+
+    async with httpx.AsyncClient(http2=False) as client:
+        toc_items: list[dict] = []
+        used_url = ""
+        for toc_url in TOC_URLS:
+            try:
+                print(f"Fetching TOC: {toc_url}")
+                html = await fetch(client, toc_url)
+                toc_items = parse_toc(html, toc_url)
+                if toc_items:
+                    used_url = toc_url
+                    break
+                print("  (no chapter links found; trying next fallback)")
+            except Exception as e:
+                print(f"  ! TOC fetch failed: {e}")
+
+        if not toc_items:
+            print(
+                "ERROR: Could not parse chapter list from any TOC URL.\n"
+                "Inspect the pages manually:\n  - " + "\n  - ".join(TOC_URLS)
+            )
+            return []
+
+        print(f"Found {len(toc_items)} chapter links in TOC ({used_url})")
+        # Soft upper bound for the LAST chapter's range.
+        last_end = toc_items[-1]["start_para"] + 2000
+
+        manifest: list[dict] = []
+        intro_count = 0
+        body_index = 0
+
+        for idx, item in enumerate(toc_items):
+            start_para = item["start_para"]
+            end_para = (
+                toc_items[idx + 1]["start_para"] if idx + 1 < len(toc_items) else last_end
+            )
+
+            low = item["title"].lower()
+            is_intro = any(
+                kw in low
+                for kw in ("preface", "foreword", "introduction", "publishers", "contents")
+            )
+            if is_intro:
+                cid = "ch00" if intro_count == 0 else f"ch00{chr(ord('a') + intro_count)}"
+                intro_count += 1
+            else:
+                body_index += 1
+                cid = f"ch{body_index:02d}"
+
+            print(f"[{idx+1}/{len(toc_items)}] Fetching: {item['title']} "
+                  f"(paras {start_para}..{end_para - 1})")
+            try:
+                title, paragraphs = await fetch_chapter_body(
+                    client, start_para, end_para, item["title"]
+                )
+                if not paragraphs:
+                    print(f"  ! no paragraphs extracted for {item['title']}")
+                    continue
+                final_title = title or item["title"]
+                filename = f"{cid}.txt"
+                out = CHAPTERS_DIR / filename
+                body = "\n\n".join(paragraphs)
+                out.write_text(f"TITLE: {final_title}\n\n{body}\n", encoding="utf-8")
+                manifest.append(
+                    {
+                        "id": cid,
+                        "title": final_title,
+                        "url": item["url"],
+                        "filename": filename,
+                        "paragraphs": len(paragraphs),
+                    }
+                )
+                print(f"  ok — {len(paragraphs)} paragraphs")
+            except Exception as e:
+                print(f"  ! failed: {e}")
+
+        MANIFEST_PATH.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        print(f"\nSaved manifest with {len(manifest)} chapters -> {MANIFEST_PATH}")
+        return manifest
+
+
+def already_crawled() -> bool:
+    if not MANIFEST_PATH.exists():
+        return False
+    try:
+        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not manifest:
+        return False
+    for entry in manifest:
+        if not (CHAPTERS_DIR / entry["filename"]).exists():
+            return False
+    return True
+
+
+def main() -> int:
+    if already_crawled():
+        print("Phase 1 skip: chapters already crawled.")
+        return 0
+    manifest = asyncio.run(crawl())
+    return 0 if manifest else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/col-translator/hugo_gen.py
+++ b/col-translator/hugo_gen.py
@@ -1,0 +1,529 @@
+"""Phase 4: generate a deployable Hugo site from translated chapters + glossary."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent
+TRANSLATED_DIR = BASE_DIR / "translated"
+CHAPTERS_DIR = BASE_DIR / "chapters"
+GLOSSARY_DIR = BASE_DIR / "glossary"
+MANIFEST_PATH = CHAPTERS_DIR / "manifest.json"
+GLOSSARY_PATH = GLOSSARY_DIR / "glossary.json"
+
+HUGO_DIR = BASE_DIR / "hugo-site"
+HUGO_CONTENT = HUGO_DIR / "content"
+HUGO_CHAPTERS = HUGO_CONTENT / "chapters"
+THEME_DIR = HUGO_DIR / "themes" / "col-theme"
+LAYOUTS_DIR = THEME_DIR / "layouts" / "_default"
+LAYOUTS_ROOT = THEME_DIR / "layouts"
+STATIC_CSS_DIR = THEME_DIR / "static" / "css"
+
+
+CONFIG_TOML = """baseURL = "https://phucam.tv/ngon-ngu-chua/"
+languageCode = "vi"
+defaultContentLanguage = "vi"
+title = "Ngụ Ngôn Của Chúa"
+theme = "col-theme"
+
+[params]
+  author = "Ellen G. White"
+  translator = "Bản dịch AI - Biên tập: PhucAm.tv"
+  description = "Ngụ Ngôn Của Chúa - Bản dịch tiếng Việt"
+  bookTitle = "Ngụ Ngôn Của Chúa"
+  originalTitle = "Christ's Object Lessons"
+
+[menu]
+  [[menu.main]]
+    name = "Các Chương"
+    url = "/chapters/"
+    weight = 1
+  [[menu.main]]
+    name = "Bảng Thuật Ngữ"
+    url = "/glossary/"
+    weight = 2
+"""
+
+THEME_TOML = """name = "col-theme"
+license = "MIT"
+description = "Clean Vietnamese-friendly theme for Christ's Object Lessons"
+min_version = "0.100.0"
+"""
+
+BASEOF_HTML = """<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode | default "vi" }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} · {{ .Site.Title }}{{ end }}</title>
+  <meta name="description" content="{{ .Site.Params.description | default .Site.Title }}">
+  <link rel="stylesheet" href="{{ "css/main.css" | relURL }}">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <a class="brand" href="{{ "/" | relURL }}">{{ .Site.Params.bookTitle | default .Site.Title }}</a>
+      <nav class="main-nav">
+        {{ range .Site.Menus.main }}
+          <a href="{{ .URL | relURL }}">{{ .Name }}</a>
+        {{ end }}
+      </nav>
+    </div>
+  </header>
+  <main class="container">
+    {{ block "main" . }}{{ end }}
+  </main>
+  <footer class="site-footer">
+    <div class="container">
+      <p class="muted">
+        {{ .Site.Params.originalTitle }} — {{ .Site.Params.author }}<br>
+        {{ .Site.Params.translator }}
+      </p>
+    </div>
+  </footer>
+</body>
+</html>
+"""
+
+SINGLE_HTML = """{{ define "main" }}
+<article class="chapter">
+  <header class="chapter-header">
+    {{ if .Params.chapter }}<p class="muted">Chương {{ .Params.chapter }}</p>{{ end }}
+    <h1>{{ .Title }}</h1>
+    {{ with .Params.original_title }}<p class="original muted">Nguyên tác: {{ . }}</p>{{ end }}
+  </header>
+
+  <div class="chapter-body">
+    {{ .Content }}
+  </div>
+
+  <nav class="chapter-nav">
+    {{ with .PrevInSection }}
+      <a class="nav-prev" href="{{ .RelPermalink }}">&larr; {{ .Title }}</a>
+    {{ else }}
+      <span></span>
+    {{ end }}
+    {{ with .NextInSection }}
+      <a class="nav-next" href="{{ .RelPermalink }}">{{ .Title }} &rarr;</a>
+    {{ else }}
+      <span></span>
+    {{ end }}
+  </nav>
+</article>
+{{ end }}
+"""
+
+LIST_HTML = """{{ define "main" }}
+<section class="chapter-list">
+  <h1>{{ .Title }}</h1>
+  {{ with .Content }}<div class="intro">{{ . }}</div>{{ end }}
+  <ol class="chapters">
+    {{ range .Pages.ByWeight }}
+      <li>
+        <a href="{{ .RelPermalink }}">
+          <span class="ch-title">{{ .Title }}</span>
+          {{ with .Params.original_title }}<span class="ch-original muted">{{ . }}</span>{{ end }}
+        </a>
+      </li>
+    {{ end }}
+  </ol>
+</section>
+{{ end }}
+"""
+
+INDEX_HTML = """{{ define "main" }}
+<section class="book-intro">
+  <h1>{{ .Site.Params.bookTitle | default .Site.Title }}</h1>
+  <p class="original muted">{{ .Site.Params.originalTitle }} — {{ .Site.Params.author }}</p>
+  {{ with .Content }}<div class="intro">{{ . }}</div>{{ end }}
+</section>
+
+<section class="chapter-list">
+  <h2>Mục Lục</h2>
+  <ol class="chapters">
+    {{ range (where .Site.RegularPages "Section" "chapters").ByWeight }}
+      <li>
+        <a href="{{ .RelPermalink }}">
+          <span class="ch-title">{{ .Title }}</span>
+          {{ with .Params.original_title }}<span class="ch-original muted">{{ . }}</span>{{ end }}
+        </a>
+      </li>
+    {{ end }}
+  </ol>
+</section>
+{{ end }}
+"""
+
+MAIN_CSS = """:root {
+  --bg: #faf9f7;
+  --text: #2d2d2d;
+  --muted: #8a8a8a;
+  --border: #e5e1db;
+  --accent: #6b4f2a;
+  --link: #3a5a99;
+  --link-hover: #1f3c78;
+}
+
+* { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  font-family: Georgia, "Times New Roman", serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.8;
+  font-size: 18px;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--border);
+  padding: 1rem 0;
+  background: #fff;
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.brand {
+  font-weight: bold;
+  font-size: 1.15rem;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.main-nav a {
+  margin-left: 1rem;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.main-nav a:hover { color: var(--link-hover); }
+
+main.container { padding-top: 2rem; padding-bottom: 4rem; }
+
+.muted { color: var(--muted); font-size: 0.92rem; }
+
+.chapter-header { margin-bottom: 2rem; text-align: center; }
+.chapter-header h1 {
+  font-size: 2rem;
+  margin: 0.3rem 0 0.6rem;
+  line-height: 1.3;
+}
+.chapter-header .original { font-style: italic; }
+
+.chapter-body p {
+  margin: 0 0 1.1rem;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.chapter-body h1,
+.chapter-body h2,
+.chapter-body h3 {
+  margin-top: 2rem;
+  line-height: 1.35;
+}
+
+.chapter-body blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1.2rem 0;
+  padding: 0.1rem 1rem;
+  color: #4a4a4a;
+  font-style: italic;
+}
+
+.chapter-body a { color: var(--link); }
+.chapter-body a:hover { color: var(--link-hover); }
+
+.chapter-nav {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.chapter-nav a {
+  display: inline-block;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: #fff;
+  color: var(--text);
+  text-decoration: none;
+  max-width: 48%;
+}
+
+.chapter-nav a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.chapter-list h1,
+.book-intro h1 {
+  font-size: 1.9rem;
+  margin-bottom: 0.4rem;
+}
+
+.chapter-list ol.chapters,
+.book-intro + .chapter-list ol.chapters {
+  list-style: none;
+  padding: 0;
+  margin: 1.2rem 0 0;
+}
+
+ol.chapters li {
+  border-bottom: 1px solid var(--border);
+  padding: 0.6rem 0;
+}
+
+ol.chapters li a {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  text-decoration: none;
+  color: var(--text);
+}
+
+ol.chapters li a:hover .ch-title { color: var(--accent); }
+
+.ch-original { flex-shrink: 0; font-style: italic; }
+
+table.glossary {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0 2rem;
+  font-size: 0.97rem;
+}
+table.glossary th, table.glossary td {
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  vertical-align: top;
+}
+table.glossary th {
+  background: #f0ebe2;
+  font-weight: bold;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 1.5rem 0;
+  margin-top: 3rem;
+  color: var(--muted);
+  font-size: 0.88rem;
+  text-align: center;
+}
+
+@media (max-width: 540px) {
+  body { font-size: 17px; }
+  .chapter-header h1 { font-size: 1.6rem; }
+  .chapter-nav { flex-direction: column; }
+  .chapter-nav a { max-width: 100%; }
+  ol.chapters li a { flex-direction: column; gap: 0.2rem; }
+}
+"""
+
+
+FRONT_MATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def parse_front_matter(md: str) -> tuple[dict, str]:
+    m = FRONT_MATTER_RE.match(md)
+    if not m:
+        return {}, md
+    fm_text = m.group(1)
+    body = md[m.end():]
+    fm: dict = {}
+    for line in fm_text.splitlines():
+        if ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        v = v.strip()
+        if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
+            v = v[1:-1]
+        fm[k.strip()] = v
+    return fm, body
+
+
+def _esc(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def load_manifest() -> list[dict]:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def load_glossary() -> list[dict]:
+    return json.loads(GLOSSARY_PATH.read_text(encoding="utf-8"))
+
+
+def sort_key_for_entry(entry: dict) -> tuple[int, str]:
+    m = re.match(r"ch(\d+)(.*)", entry["id"])
+    if not m:
+        return (999, entry["id"])
+    return (int(m.group(1)), m.group(2))
+
+
+def generate_chapters(manifest: list[dict]) -> int:
+    HUGO_CHAPTERS.mkdir(parents=True, exist_ok=True)
+    # Clean out any stale previous outputs
+    for old in HUGO_CHAPTERS.glob("*.md"):
+        old.unlink()
+
+    ordered = sorted(manifest, key=sort_key_for_entry)
+    written = 0
+    weight = 10
+    for entry in ordered:
+        src = TRANSLATED_DIR / f"{entry['id']}.md"
+        if not src.exists():
+            print(f"  (skipped {entry['id']}: no translation yet)")
+            continue
+        md = src.read_text(encoding="utf-8")
+        fm, body = parse_front_matter(md)
+        title = fm.get("title") or entry["title"]
+        original_title = fm.get("original_title") or entry["title"]
+        chapter_no = fm.get("chapter") or (re.sub(r"\D", "", entry["id"]) or "0")
+
+        new_fm_lines = [
+            "---",
+            f'title: "{_esc(title)}"',
+            f"weight: {weight}",
+            f"chapter: {chapter_no}",
+            f'original_title: "{_esc(original_title)}"',
+            f'slug: "{entry["id"]}"',
+            "draft: false",
+            "---",
+            "",
+        ]
+        out = HUGO_CHAPTERS / f"{entry['id']}.md"
+        out.write_text("\n".join(new_fm_lines) + body.lstrip("\n"), encoding="utf-8")
+        weight += 10
+        written += 1
+    return written
+
+
+def generate_index(manifest: list[dict]) -> None:
+    HUGO_CONTENT.mkdir(parents=True, exist_ok=True)
+    body = (
+        '---\n'
+        'title: "Ngụ Ngôn Của Chúa"\n'
+        '---\n\n'
+        'Chào mừng bạn đến với bản dịch tiếng Việt của "Christ\'s Object Lessons" '
+        "— *Ngụ Ngôn Của Chúa* — bởi Ellen G. White.\n\n"
+        "Sách này khám phá những ngụ ngôn của Đức Chúa Giê-su, mỗi chương soi sáng "
+        "một chân lý thuộc linh khác nhau cho đời sống Cơ-đốc.\n"
+    )
+    (HUGO_CONTENT / "_index.md").write_text(body, encoding="utf-8")
+
+    ordered = sorted(manifest, key=sort_key_for_entry)
+    list_front = (
+        '---\n'
+        'title: "Các Chương"\n'
+        '---\n\n'
+        f"Toàn bộ {len(ordered)} chương của sách *Ngụ Ngôn Của Chúa*.\n"
+    )
+    (HUGO_CHAPTERS / "_index.md").write_text(list_front, encoding="utf-8")
+
+
+def generate_glossary(glossary: list[dict]) -> None:
+    by_cat: dict[str, list[dict]] = {}
+    for t in glossary:
+        by_cat.setdefault(t["category"], []).append(t)
+
+    cat_labels = {
+        "theology": "Thần Học",
+        "proper_noun": "Danh Từ Riêng",
+        "parable_title": "Tên Ngụ Ngôn",
+        "ellen_white_idiom": "Thành Ngữ Ellen G. White",
+    }
+
+    lines = [
+        "---",
+        'title: "Bảng Thuật Ngữ"',
+        "---",
+        "",
+        "Các thuật ngữ và danh từ riêng được dùng nhất quán trong bản dịch này.",
+        "",
+    ]
+    for cat in sorted(by_cat, key=lambda c: cat_labels.get(c, c)):
+        label = cat_labels.get(cat, cat.replace("_", " ").title())
+        lines.append(f"## {label}")
+        lines.append("")
+        lines.append('<table class="glossary">')
+        lines.append("  <thead><tr><th>Tiếng Việt</th><th>Tiếng Anh</th><th>Ghi chú</th></tr></thead>")
+        lines.append("  <tbody>")
+        for t in sorted(by_cat[cat], key=lambda x: x["vi"].lower()):
+            note = t.get("note") or ""
+            vi = t["vi"].replace("<", "&lt;").replace(">", "&gt;")
+            en = t["en"].replace("<", "&lt;").replace(">", "&gt;")
+            note = note.replace("<", "&lt;").replace(">", "&gt;")
+            lines.append(f"    <tr><td>{vi}</td><td>{en}</td><td>{note}</td></tr>")
+        lines.append("  </tbody>")
+        lines.append("</table>")
+        lines.append("")
+
+    (HUGO_CONTENT / "glossary.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_theme() -> None:
+    LAYOUTS_DIR.mkdir(parents=True, exist_ok=True)
+    LAYOUTS_ROOT.mkdir(parents=True, exist_ok=True)
+    STATIC_CSS_DIR.mkdir(parents=True, exist_ok=True)
+
+    (THEME_DIR / "theme.toml").write_text(THEME_TOML, encoding="utf-8")
+    (LAYOUTS_DIR / "baseof.html").write_text(BASEOF_HTML, encoding="utf-8")
+    (LAYOUTS_DIR / "single.html").write_text(SINGLE_HTML, encoding="utf-8")
+    (LAYOUTS_DIR / "list.html").write_text(LIST_HTML, encoding="utf-8")
+    (LAYOUTS_ROOT / "index.html").write_text(INDEX_HTML, encoding="utf-8")
+    (STATIC_CSS_DIR / "main.css").write_text(MAIN_CSS, encoding="utf-8")
+
+
+def write_config() -> None:
+    HUGO_DIR.mkdir(parents=True, exist_ok=True)
+    (HUGO_DIR / "config.toml").write_text(CONFIG_TOML, encoding="utf-8")
+
+
+def main() -> int:
+    if not MANIFEST_PATH.exists():
+        raise SystemExit("manifest.json missing; run phase 1 first")
+    if not GLOSSARY_PATH.exists():
+        raise SystemExit("glossary.json missing; run phase 2 first")
+
+    manifest = load_manifest()
+    glossary = load_glossary()
+
+    write_config()
+    write_theme()
+    count = generate_chapters(manifest)
+    generate_index(manifest)
+    generate_glossary(glossary)
+
+    print(f"Hugo site generated at {HUGO_DIR}")
+    print(f"  - {count} chapter pages")
+    print(f"  - {len(glossary)} glossary entries")
+    print("  - theme: col-theme")
+    print("\nRun:  cd col-translator/hugo-site && hugo server")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/col-translator/orchestrator.py
+++ b/col-translator/orchestrator.py
@@ -1,0 +1,343 @@
+"""Phase 3: Translate all chapters to Vietnamese with shared glossary."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from anthropic import AsyncAnthropic
+
+BASE_DIR = Path(__file__).parent
+CHAPTERS_DIR = BASE_DIR / "chapters"
+GLOSSARY_DIR = BASE_DIR / "glossary"
+TRANSLATED_DIR = BASE_DIR / "translated"
+MANIFEST_PATH = CHAPTERS_DIR / "manifest.json"
+GLOSSARY_PATH = GLOSSARY_DIR / "glossary.json"
+
+TRANSLATE_MODEL = "claude-sonnet-4-20250514"
+SUMMARY_MODEL = "claude-haiku-3-5-latest"
+MAX_TOKENS_TRANSLATE = 8192
+MAX_TOKENS_SUMMARY = 512
+MAX_CONCURRENCY = 3
+
+# Rough pricing (USD per 1M tokens) for reporting only.
+PRICING = {
+    TRANSLATE_MODEL: {"input": 3.0, "output": 15.0},
+    SUMMARY_MODEL: {"input": 0.80, "output": 4.0},
+}
+
+
+STYLE_RULES = """\
+Content rules (MUST FOLLOW):
+- Always use "Đức Chúa Giê-su" (never "Chúa Giê-su", "Jesus", or "Giê-xu").
+- "Sa-bát" (not "Sabát").
+- "Do Thái Giáo" (not "Giu-đa-izt").
+- "Cơ-đốc" (not "Cơ Đốc").
+- Divine names capitalized: "Đức Chúa Trời", "Đức Thánh Linh", "Kinh Thánh", "Đức Chúa Giê-su".
+- When Chúa/God is the subject, use "ban phước" (never "chúc phước").
+"""
+
+SYSTEM_PROMPT_TEMPLATE = """You are an expert Vietnamese translator specializing in Seventh-day Adventist theological literature.
+Your translation must be faithful, literary, and spiritually resonant — matching the devotional tone of Ellen G. White.
+
+{style_rules}
+
+GLOSSARY (use these translations without deviation for all listed terms):
+{glossary_table}
+
+Rules:
+1. Every glossary term MUST use the exact Vietnamese translation listed — no synonyms.
+2. Preserve all paragraph breaks. Do not merge or split paragraphs.
+3. Maintain Ellen White's rhetorical style: declarative, devotional, occasionally sermonic.
+4. Proper nouns not in the glossary: transliterate or use standard Vietnamese Bible (1934 translation) equivalents.
+5. Bible verse references (e.g. "John 3:16"): keep the reference notation as-is, translate the quoted text if any.
+6. Output ONLY the Vietnamese translation. No preamble, no notes, no "Here is the translation:".
+7. Start with the chapter title as a level-1 markdown heading."""
+
+USER_PROMPT_TEMPLATE = """PREVIOUS CHAPTER SUMMARY (for narrative continuity):
+{prev_summary}
+
+CHAPTER: {title}
+---
+{chapter_text}"""
+
+
+def load_manifest() -> list[dict]:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def load_glossary() -> list[dict]:
+    return json.loads(GLOSSARY_PATH.read_text(encoding="utf-8"))
+
+
+def format_glossary_table(glossary: list[dict]) -> str:
+    """2-column markdown table, grouped by category, sorted alphabetically."""
+    by_cat: dict[str, list[dict]] = {}
+    for t in glossary:
+        by_cat.setdefault(t["category"], []).append(t)
+
+    parts: list[str] = []
+    for cat in sorted(by_cat):
+        parts.append(f"\n### {cat}\n")
+        parts.append("| English | Vietnamese |")
+        parts.append("|---|---|")
+        for t in sorted(by_cat[cat], key=lambda x: x["en"].lower()):
+            en = t["en"].replace("|", "\\|")
+            vi = t["vi"].replace("|", "\\|")
+            parts.append(f"| {en} | {vi} |")
+    return "\n".join(parts)
+
+
+def _read_chapter_body(entry: dict) -> tuple[str, str]:
+    """Return (title, body) where the TITLE: header is stripped from body."""
+    raw = (CHAPTERS_DIR / entry["filename"]).read_text(encoding="utf-8")
+    lines = raw.splitlines()
+    title = entry["title"]
+    body_lines = lines
+    if lines and lines[0].startswith("TITLE:"):
+        title = lines[0].removeprefix("TITLE:").strip() or title
+        body_lines = lines[1:]
+    body = "\n".join(body_lines).strip()
+    return title, body
+
+
+def _slugify_title(title: str) -> str:
+    t = title.strip().strip('"').strip("'")
+    # Strip any leading markdown heading marker
+    t = re.sub(r"^#+\s*", "", t)
+    return t
+
+
+def _split_title_from_translation(md: str, fallback: str) -> tuple[str, str]:
+    """Pull the leading '# Title' out of the translated markdown body."""
+    md = md.strip()
+    m = re.match(r"^#\s+(.+?)\s*\n+", md)
+    if m:
+        title = _slugify_title(m.group(1))
+        body = md[m.end():].strip()
+        return title, body
+    return fallback, md
+
+
+class CostTracker:
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, int, int]] = []
+
+    def add(self, model: str, input_tokens: int, output_tokens: int) -> None:
+        self.rows.append((model, input_tokens, output_tokens))
+
+    def total(self) -> tuple[float, int, int]:
+        usd = 0.0
+        tin = tout = 0
+        for model, i, o in self.rows:
+            tin += i
+            tout += o
+            rate = PRICING.get(model, {"input": 0.0, "output": 0.0})
+            usd += (i / 1_000_000) * rate["input"] + (o / 1_000_000) * rate["output"]
+        return usd, tin, tout
+
+    def report(self) -> str:
+        usd, tin, tout = self.total()
+        return f"Tokens in={tin:,} out={tout:,}  est cost=${usd:.4f}"
+
+
+async def translate_chapter(
+    client: AsyncAnthropic,
+    entry: dict,
+    glossary_table: str,
+    prev_summary: str,
+    cost: CostTracker,
+) -> str:
+    """Call Claude to translate one chapter. Returns raw translated markdown."""
+    title, body = _read_chapter_body(entry)
+    system = SYSTEM_PROMPT_TEMPLATE.format(
+        style_rules=STYLE_RULES, glossary_table=glossary_table
+    )
+    user = USER_PROMPT_TEMPLATE.format(
+        prev_summary=prev_summary or "(This is the first chapter.)",
+        title=title,
+        chapter_text=body,
+    )
+
+    last_err: Exception | None = None
+    for attempt in range(2):
+        try:
+            resp = await client.messages.create(
+                model=TRANSLATE_MODEL,
+                max_tokens=MAX_TOKENS_TRANSLATE,
+                system=system,
+                messages=[{"role": "user", "content": user}],
+            )
+            text = "".join(
+                b.text for b in resp.content if getattr(b, "type", "") == "text"
+            )
+            cost.add(TRANSLATE_MODEL, resp.usage.input_tokens, resp.usage.output_tokens)
+            return text.strip()
+        except Exception as e:
+            last_err = e
+            print(f"  ! translate attempt {attempt+1} for {entry['id']} failed: {e}")
+            await asyncio.sleep(2 ** attempt)
+    raise RuntimeError(f"translate failed for {entry['id']}: {last_err}")
+
+
+async def summarize(
+    client: AsyncAnthropic, translated_body: str, cost: CostTracker
+) -> str:
+    """Generate a ~150-word Vietnamese summary of the translated chapter."""
+    system = (
+        "Bạn tóm tắt chương sách thần học bằng tiếng Việt, khoảng 150 từ, "
+        "trang trọng, mạch lạc, giữ đúng các thuật ngữ chính. "
+        "Chỉ xuất phần tóm tắt, không thêm tiêu đề hay lời mở đầu."
+    )
+    # Cap input body to a reasonable size to control cost.
+    capped = translated_body[:8000]
+    try:
+        resp = await client.messages.create(
+            model=SUMMARY_MODEL,
+            max_tokens=MAX_TOKENS_SUMMARY,
+            system=system,
+            messages=[{"role": "user", "content": f"Hãy tóm tắt chương sau:\n\n{capped}"}],
+        )
+        cost.add(SUMMARY_MODEL, resp.usage.input_tokens, resp.usage.output_tokens)
+        return "".join(
+            b.text for b in resp.content if getattr(b, "type", "") == "text"
+        ).strip()
+    except Exception as e:
+        print(f"  ! summary failed: {e}")
+        return ""
+
+
+def write_translated(entry: dict, translated_md: str, chapter_num: int) -> None:
+    title, body = _split_title_from_translation(translated_md, entry["title"])
+    front_matter = (
+        "---\n"
+        f'title: "{title.replace(chr(34), chr(92) + chr(34))}"\n'
+        f"chapter: {chapter_num}\n"
+        f'original_title: "{entry["title"].replace(chr(34), chr(92) + chr(34))}"\n'
+        "draft: false\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"{body}\n"
+    )
+    out = TRANSLATED_DIR / f"{entry['id']}.md"
+    out.write_text(front_matter, encoding="utf-8")
+
+
+def chapter_number(entry: dict) -> int:
+    m = re.match(r"ch(\d+)", entry["id"])
+    return int(m.group(1)) if m else 0
+
+
+async def run_sequential(
+    entries: list[dict], glossary_table: str, retranslate: bool
+) -> CostTracker:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise SystemExit("ANTHROPIC_API_KEY is not set")
+    TRANSLATED_DIR.mkdir(parents=True, exist_ok=True)
+
+    cost = CostTracker()
+    prev_summary = ""
+
+    async with AsyncAnthropic(api_key=api_key) as client:
+        for idx, entry in enumerate(entries, start=1):
+            out = TRANSLATED_DIR / f"{entry['id']}.md"
+            if out.exists() and not retranslate:
+                print(f"[{idx}/{len(entries)}] skip {entry['id']} (exists)")
+                continue
+            print(f"[{idx}/{len(entries)}] translating {entry['id']} — {entry['title']}")
+            try:
+                md = await translate_chapter(
+                    client, entry, glossary_table, prev_summary, cost
+                )
+                write_translated(entry, md, chapter_number(entry))
+                _, body_only = _split_title_from_translation(md, entry["title"])
+                prev_summary = await summarize(client, body_only, cost)
+                print(f"  ok; {cost.report()}")
+            except Exception as e:
+                print(f"  !! chapter failed: {e}")
+                (TRANSLATED_DIR / f"{entry['id']}.error.txt").write_text(
+                    str(e), encoding="utf-8"
+                )
+    return cost
+
+
+async def run_parallel(
+    entries: list[dict], glossary_table: str, retranslate: bool
+) -> CostTracker:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise SystemExit("ANTHROPIC_API_KEY is not set")
+    TRANSLATED_DIR.mkdir(parents=True, exist_ok=True)
+    cost = CostTracker()
+    sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+    async with AsyncAnthropic(api_key=api_key) as client:
+        async def worker(entry: dict, i: int) -> None:
+            out = TRANSLATED_DIR / f"{entry['id']}.md"
+            if out.exists() and not retranslate:
+                print(f"[{i}/{len(entries)}] skip {entry['id']} (exists)")
+                return
+            async with sem:
+                print(f"[{i}/{len(entries)}] translating {entry['id']} — {entry['title']}")
+                try:
+                    md = await translate_chapter(client, entry, glossary_table, "", cost)
+                    write_translated(entry, md, chapter_number(entry))
+                    print(f"  ok {entry['id']}; {cost.report()}")
+                except Exception as e:
+                    print(f"  !! {entry['id']} failed: {e}")
+                    (TRANSLATED_DIR / f"{entry['id']}.error.txt").write_text(
+                        str(e), encoding="utf-8"
+                    )
+
+        await asyncio.gather(
+            *[worker(e, i) for i, e in enumerate(entries, start=1)]
+        )
+    return cost
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Phase 3: translate chapters")
+    p.add_argument("--parallel", action="store_true", help="skip summary chaining, run concurrently")
+    p.add_argument("--retranslate", action="store_true", help="overwrite existing translations")
+    p.add_argument("--chapter", type=int, help="only (re)translate one chapter number")
+    p.add_argument("--test", action="store_true", help="only first 2 chapters")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = load_manifest()
+    if not manifest:
+        raise SystemExit("Manifest is empty")
+    if not GLOSSARY_PATH.exists():
+        raise SystemExit("glossary.json missing; run phase 2 first")
+
+    glossary = load_glossary()
+    glossary_table = format_glossary_table(glossary)
+
+    entries = manifest
+    if args.chapter is not None:
+        want = f"ch{args.chapter:02d}"
+        entries = [e for e in manifest if e["id"] == want]
+        if not entries:
+            raise SystemExit(f"chapter {want} not in manifest")
+        args.retranslate = True
+    elif args.test:
+        entries = manifest[:2]
+
+    if args.parallel:
+        cost = asyncio.run(run_parallel(entries, glossary_table, args.retranslate))
+    else:
+        cost = asyncio.run(run_sequential(entries, glossary_table, args.retranslate))
+
+    print(f"\nPhase 3 done. {cost.report()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/col-translator/requirements.txt
+++ b/col-translator/requirements.txt
@@ -1,0 +1,6 @@
+anthropic>=0.40.0
+httpx>=0.27.0
+beautifulsoup4>=4.12.0
+lxml>=5.0.0
+python-slugify>=8.0.0
+pyyaml>=6.0.1

--- a/col-translator/run_all.py
+++ b/col-translator/run_all.py
@@ -1,0 +1,144 @@
+"""Master runner for the COL Vietnamese translation pipeline.
+
+Usage:
+  python run_all.py                 # run all phases
+  python run_all.py --phase 1       # run only phase 1
+  python run_all.py --phase 2       # run only phase 2
+  python run_all.py --from-phase 3  # run phase 3 onwards
+  python run_all.py --chapter 5     # re-translate only chapter 5
+  python run_all.py --test          # run phases 1+2 on first 2 chapters (fast sanity check)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import crawler
+import build_glossary
+import orchestrator
+import hugo_gen
+
+BASE_DIR = Path(__file__).parent
+MANIFEST_PATH = BASE_DIR / "chapters" / "manifest.json"
+GLOSSARY_PATH = BASE_DIR / "glossary" / "glossary.json"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="COL translation pipeline runner")
+    p.add_argument("--phase", type=int, choices=[1, 2, 3, 4], help="run only this phase")
+    p.add_argument("--from-phase", type=int, choices=[1, 2, 3, 4], default=1)
+    p.add_argument("--chapter", type=int, help="retranslate only this chapter (implies phases 3+4)")
+    p.add_argument("--rebuild-glossary", action="store_true")
+    p.add_argument("--retranslate", action="store_true")
+    p.add_argument("--parallel", action="store_true", help="phase 3 parallel mode")
+    p.add_argument("--test", action="store_true", help="only first 2 chapters, phases 1+2 only")
+    return p.parse_args(argv)
+
+
+def _phase1() -> None:
+    t0 = time.time()
+    print("\n=== Phase 1: crawl ===")
+    if crawler.already_crawled():
+        print("Phase 1 skip: chapters already crawled.")
+    else:
+        asyncio.run(crawler.crawl())
+    print(f"Phase 1 duration: {time.time() - t0:.1f}s")
+
+
+def _truncate_manifest_for_test() -> list[dict] | None:
+    """In --test mode, back up the manifest and keep only first 2 entries on disk."""
+    if not MANIFEST_PATH.exists():
+        return None
+    full = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if len(full) <= 2:
+        return None
+    short = full[:2]
+    MANIFEST_PATH.write_text(json.dumps(short, ensure_ascii=False, indent=2), encoding="utf-8")
+    return full
+
+
+def _restore_manifest(full: list[dict] | None) -> None:
+    if full is None:
+        return
+    MANIFEST_PATH.write_text(json.dumps(full, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _phase2(rebuild: bool, test_mode: bool = False) -> None:
+    t0 = time.time()
+    print("\n=== Phase 2: glossary ===")
+    if GLOSSARY_PATH.exists() and not rebuild:
+        print(f"Phase 2 skip: glossary exists at {GLOSSARY_PATH}.")
+    else:
+        backup = _truncate_manifest_for_test() if test_mode else None
+        try:
+            build_glossary.build()
+        finally:
+            _restore_manifest(backup)
+    print(f"Phase 2 duration: {time.time() - t0:.1f}s")
+
+
+def _phase3(args: argparse.Namespace) -> None:
+    t0 = time.time()
+    print("\n=== Phase 3: translate ===")
+    argv: list[str] = []
+    if args.parallel:
+        argv.append("--parallel")
+    if args.retranslate:
+        argv.append("--retranslate")
+    if args.chapter is not None:
+        argv.extend(["--chapter", str(args.chapter)])
+    orchestrator.main(argv)
+    print(f"Phase 3 duration: {time.time() - t0:.1f}s")
+
+
+def _phase4() -> None:
+    t0 = time.time()
+    print("\n=== Phase 4: hugo gen ===")
+    hugo_gen.main()
+    print(f"Phase 4 duration: {time.time() - t0:.1f}s")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not os.environ.get("ANTHROPIC_API_KEY") and (
+        args.phase in (2, 3) or args.from_phase <= 3 or args.chapter is not None
+    ):
+        print("WARNING: ANTHROPIC_API_KEY not set — phases 2 and 3 will fail.")
+
+    if args.chapter is not None:
+        # Targeted re-translate of a single chapter, then regenerate Hugo.
+        _phase3(args)
+        _phase4()
+        return 0
+
+    if args.test:
+        _phase1()
+        _phase2(rebuild=args.rebuild_glossary, test_mode=True)
+        print("\nTest mode done (phases 1+2 on first 2 chapters).")
+        return 0
+
+    run = set()
+    if args.phase is not None:
+        run = {args.phase}
+    else:
+        run = {p for p in (1, 2, 3, 4) if p >= args.from_phase}
+
+    if 1 in run:
+        _phase1()
+    if 2 in run:
+        _phase2(rebuild=args.rebuild_glossary)
+    if 3 in run:
+        _phase3(args)
+    if 4 in run:
+        _phase4()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Five-phase pipeline under col-translator/: crawl chapters from
egwwritings.org (book id 15), extract a shared EN→VI theological
glossary via Claude, translate each chapter with glossary-enforced
sub-agents plus rolling summary chaining, and generate a deployable
Hugo site with a clean Vietnamese-friendly theme. Enforces phucam.tv
content rules (Đức Chúa Giê-su, Sa-bát, etc.) in system prompts.

https://claude.ai/code/session_01M9mPUQW3yXM6hzJGBQaQwT